### PR TITLE
fixed a thread bomb problem by first caching the images for the uitablev...

### DIFF
--- a/GSFDataCollecter.xcodeproj/project.pbxproj
+++ b/GSFDataCollecter.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 				ORGANIZATIONNAME = "Michael Baptist - LLNL";
 				TargetAttributes = {
 					DBB428361880A64F00139082 = {
-						DevelopmentTeam = Z5SLZ6QPTL;
+						DevelopmentTeam = 58K2V57UB6;
 					};
 					DBB4285A1880A64F00139082 = {
 						TestTargetID = DBB428361880A64F00139082;


### PR DESCRIPTION
...iew for offline mode, and second by removing the dispatch queue that was being created all the time in cellForIndexAtPath. another feature was the completion handler that loads the images very cleanly when the table is first updated so the images load nice now and don’t need to be scrolled to be loaded. one problem that may still exist is the file deletion on send seemed to have a problem needs to be tested more.
