### PR TITLE
Fixed an image rotation bug in the image preview VC.

### DIFF
--- a/GSFDataCollecter/GSFImageSelectorPreview.m
+++ b/GSFDataCollecter/GSFImageSelectorPreview.m
@@ -23,9 +23,7 @@
     [super viewDidLoad];
 	// Do any additional setup after loading the view.
     GSFOpenCvImageProcessor *pro = [[GSFOpenCvImageProcessor alloc] init];
-    if (self.image.imageOrientation == UIImageOrientationLeft) { // requires 90 clockwise rotation
-        self.image = [pro rotateImage:self.image byDegrees:180];
-    } else if (self.image.imageOrientation == UIImageOrientationUp) { // 90 counter clock
+    if (self.image.imageOrientation == UIImageOrientationUp) { // 90 counter clock
         self.image = [pro rotateImage:self.image byDegrees:-90];
     } else if (self.image.imageOrientation == UIImageOrientationDown) { // 180 rotation.
         self.image = [pro rotateImage:self.image byDegrees:90];

--- a/GSFDataCollecter/GSFOpenCvImageProcessor.h
+++ b/GSFDataCollecter/GSFOpenCvImageProcessor.h
@@ -13,16 +13,37 @@
 
 @interface GSFOpenCvImageProcessor : NSObject
 
-//  Facial Detection. pass an array of gsfdata objects and gsfimage params will be filled.
+/**
+ *  Uses OpenCV to detect human faces in the images contained with in the array of data that is passed in. GSFData objects should be passed in and the GSFImage params will be filled. GSFImages lie within these GSFData objects and they are the images that will be used during the detection algorithm.
+ *
+ *  @param capturedImages An array of GSFData objects.
+ */
 - (void)detectFacesUsingImageArray:(NSMutableArray *)capturedImages;
 
-// Person Detection (whole body) pass an array of gsfdata objects and gsfimage params will be filled.
+/**
+ *  Uses OpenCV to detect human bodies in the images contained with in the array of data that is passed in. GSFData objects should be passed in and the GSFImage params will be filled. GSFImages lie within these GSFData objects and they are the images that will be used during the detection algorithm. Note: Detects Full Bodies such as a pedestrian.
+ *
+ *  @param capturedImages An Array of GSFData objects.
+ */
 - (void)detectPeopleUsingImageArray:(NSMutableArray *)capturedImages;
 
-// rotate image by degrees.
+/**
+ *  Rotates an image by a certain number of degrees. This has an effect on the bits of the image.
+ *
+ *  @param image   The image to be rotated.
+ *  @param degrees The number in degrees that the image will be rotated by.
+ *
+ *  @return The image passed in rotated by the specified number of degrees.
+ */
 - (UIImage *)rotateImage:(UIImage*)image byDegrees:(CGFloat)degrees;
 
-// scales an image to 480x640 or 640x480 depending on its orientaiton
+/**
+ *  Takes an image and resizes it to the scale of the front facing camera. This is to speed up any processing on the image, lower disk consumption. For iPhone4/4s this is 480x640 or 640x480 and for iPhone5/5s it is (fill in).
+ *
+ *  @param image The image to be resized.
+ *
+ *  @return The resized image.
+ */
 - (UIImage *)resizedImage:(UIImage *)image;
 
 @end

--- a/GSFDataCollecter/GSFOpenCvImageProcessor.mm
+++ b/GSFDataCollecter/GSFOpenCvImageProcessor.mm
@@ -16,16 +16,36 @@
 
 @interface GSFOpenCvImageProcessor ()
 
-// convert image from UIImage to cvMat format to use the opencv framework.
+/**
+ *  Converts an image taken from the iPhone into the cv::cvMat format so that the OpenCV framework can perform image processing on the cv::cvMat.
+ *
+ *  @param image The image to be converted into cv::cvMat.
+ *
+ *  @return The cv::cvMat data type from the UIImage passed in.
+ */
 - (cv::Mat)cvMatFromUIImage:(UIImage *)image;
 
-// conver image from cvMat to UIImage for after the image is processed.
+/**
+ *  Converts an OpenCV cv::cvMat formatted image into an Apple UIImage to be used for iOS or OSX applications.
+ *
+ *  @param cvMatImage The cv::cvMat data type to be converted into an Apple UIImage.
+ *
+ *  @return A UIImage.
+ */
 - (UIImage *)UIImageFromCvMat:(cv::Mat)cvMatImage;
 
 @end
 
 @implementation GSFOpenCvImageProcessor
 
+/**
+ *  Rotates an image by a certain number of degrees. This has an effect on the bits of the image.
+ *
+ *  @param image   The image to be rotated.
+ *  @param degrees The number in degrees that the image will be rotated by.
+ *
+ *  @return The image passed in rotated by the specified number of degrees.
+ */
 - (UIImage *)rotateImage:(UIImage*)image byDegrees:(CGFloat)degrees
 {
     // calculate the size of the rotated view's containing box for our drawing space
@@ -54,12 +74,28 @@
     
 }
 
+/**
+ *  Takes an image and resizes it to the scale of the front facing camera. This is to speed up any processing on the image, lower disk consumption. For iPhone4/4s this is 480x640 or 640x480 and for iPhone5/5s it is (fill in).
+ *
+ *  @param image The image to be resized.
+ *
+ *  @return The resized image.
+ */
 - (UIImage *)resizedImage:(UIImage *)image {
     CGRect newRect;
+    CGRect screenBound = [[UIScreen mainScreen] bounds];
     if (image.imageOrientation == UIImageOrientationLeft || image.imageOrientation == UIImageOrientationRight) {
-        newRect = CGRectIntegral(CGRectMake(0, 0, 480, 640));
+        if (screenBound.size.height > 480) { // iphone 5 image
+            //newRect = CGRectIntegral(CGRectMake(0, 0, , ));
+        } else { // iphone 4 image
+            newRect = CGRectIntegral(CGRectMake(0, 0, 480, 640));
+        }
     } else if (image.imageOrientation == UIImageOrientationUp || image.imageOrientation == UIImageOrientationDown) {
-        newRect = CGRectIntegral(CGRectMake(0, 0, 640, 480));
+        if (screenBound.size.height > 480) { // iphone 5 image
+            //newRect = CGRectIntegral(CGRectMake(0, 0, , ));
+        } else { // iphone 4 image
+            newRect = CGRectIntegral(CGRectMake(0, 0, 640, 480));
+        }
     }
     CGImageRef imageRef = image.CGImage;
 
@@ -91,7 +127,13 @@
     return newImage;
 }
 
-// convert image from UIImage to cvMat format to use the opencv framework.
+/**
+ *  Converts an image taken from the iPhone into the cv::cvMat format so that the OpenCV framework can perform image processing on the cv::cvMat.
+ *
+ *  @param image The image to be converted into cv::cvMat.
+ *
+ *  @return The cv::cvMat data type from the UIImage passed in.
+ */
 - (cv::Mat)cvMatFromUIImage:(UIImage *)image
 {
     if (image.imageOrientation == UIImageOrientationRight) { // requires 90 clockwise rotation
@@ -128,6 +170,13 @@
 }
 
 // convert image from cvMat to UIImage for after the image is processed.
+/**
+ *  Converts an OpenCV cv::cvMat formatted image into an Apple UIImage to be used for iOS or OSX applications.
+ *
+ *  @param cvMatImage The cv::cvMat data type to be converted into an Apple UIImage.
+ *
+ *  @return A UIImage.
+ */
 - (UIImage *)UIImageFromCvMat:(cv::Mat)cvMatImage;
 {
     NSData *data = [NSData dataWithBytes:cvMatImage.data length:cvMatImage.elemSize()*cvMatImage.total()];
@@ -143,8 +192,11 @@
     return finalImage;
 }
 
-// detects a person in a photo.
-- (void)detectPeopleUsingImageArray:(NSMutableArray *)capturedImages
+/**
+ *  Uses OpenCV to detect human bodies in the images contained with in the array of data that is passed in. GSFData objects should be passed in and the GSFImage params will be filled. GSFImages lie within these GSFData objects and they are the images that will be used during the detection algorithm. Note: Detects Full Bodies such as a pedestrian.
+ *
+ *  @param capturedImages An Array of GSFData objects.
+ */- (void)detectPeopleUsingImageArray:(NSMutableArray *)capturedImages
 {
     cv::HOGDescriptor hog;
     hog.setSVMDetector(cv::HOGDescriptor::getDefaultPeopleDetector());
@@ -181,6 +233,11 @@
     }
 }
 
+/**
+ *  Uses OpenCV to detect human faces in the images contained with in the array of data that is passed in. GSFData objects should be passed in and the GSFImage params will be filled. GSFImages lie within these GSFData objects and they are the images that will be used during the detection algorithm.
+ *
+ *  @param capturedImages An array of GSFData objects.
+ */
 - (void)detectFacesUsingImageArray:(NSMutableArray *)capturedImages
 {
     for (GSFData *data in capturedImages) {

--- a/GSFDataCollecter/GSFSavedDataDetailViewController.m
+++ b/GSFDataCollecter/GSFSavedDataDetailViewController.m
@@ -54,14 +54,8 @@
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
     // Return the number of rows in the section.
-    // this should be the number of properties
-    // -2 from the images due to the fact that we want a row for all 3 images to segue from
-    // +1 due to gps coordinates in separate dict
-    NSDictionary *properties = nil;
-    if ([[self.feature objectForKey:@"properties"] isKindOfClass:[NSDictionary class]]) {
-        properties = [self.feature objectForKey:@"properties"];
-    }
-    return properties.count - 1;
+    // this should be the number of properties in a GSF Geojson object.
+    return 8;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -89,9 +83,8 @@
                 properties = [self.feature objectForKey:@"properties"];
             }
             if(2 == indexPath.row) {
-                NSDate *date = [NSDate dateWithTimeIntervalSince1970:[[properties objectForKey:@"timestamp"] doubleValue]];
                 NSString *datestring = @"Date: ";
-                cell.textLabel.text = [datestring stringByAppendingString:[date description]];
+                cell.textLabel.text = [datestring stringByAppendingString:[properties objectForKey:@"timestamp"]];
             } else if (3 == indexPath.row) {
                 if ([properties objectForKey:@"altitude"]) {
                     cell.textLabel.text = [[NSString alloc] initWithFormat:@"Altitude: %.2fm", [[properties objectForKey:@"altitude"] doubleValue]];
@@ -107,10 +100,14 @@
             } else if (6 == indexPath.row) {
                 if ([properties objectForKey:@"faces_detected"]) {
                     cell.textLabel.text = [[NSString alloc] initWithFormat:@"Faces: %d detected.", [[properties objectForKey:@"faces_detected"] intValue]];
+                } else {
+                    cell.textLabel.text = [[NSString alloc] initWithFormat:@"Faces: 0."];
                 }
             } else if (7 == indexPath.row) {
                 if ([properties objectForKey:@"people_detected"]) {
                     cell.textLabel.text = [[NSString alloc] initWithFormat:@"People: %d detected.", [[properties objectForKey:@"people_detected"] intValue]];
+                } else {
+                    cell.textLabel.text = [[NSString alloc] initWithFormat:@"People: 0."];
                 }
             }
         }
@@ -133,9 +130,18 @@
         GSFSavedDataImageViewController *controller = (GSFSavedDataImageViewController*)segue.destinationViewController;
         if ([[self.feature objectForKey:@"properties"] isKindOfClass:[NSDictionary class]]) {
             NSDictionary *properties = [self.feature objectForKey:@"properties"];
-            UIImage *oimage = [[UIImage alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:[properties objectForKey:@"oimage"] options:0]];
-            UIImage *pimage = [[UIImage alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:[properties objectForKey:@"pimage"] options:0]];
-            UIImage *fimage = [[UIImage alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:[properties objectForKey:@"fimage"] options:0]];
+            UIImage *oimage = nil;
+            UIImage *fimage = nil;
+            UIImage *pimage = nil;
+            if ([properties objectForKey:@"oimage"]) {
+                oimage = [[UIImage alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:[properties objectForKey:@"oimage"] options:0]];
+            }
+            if ([properties objectForKey:@"pimage"]) {
+                pimage = [[UIImage alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:[properties objectForKey:@"pimage"] options:0]];
+            }
+            if ([properties objectForKey:@"fimage"]) {
+                fimage = [[UIImage alloc] initWithData:[[NSData alloc] initWithBase64EncodedString:[properties objectForKey:@"fimage"] options:0]];
+            }
             NSArray *images = [[NSArray alloc] initWithObjects:oimage, pimage, fimage, nil];
             controller.images = images;
         }

--- a/GSFDataCollecter/GSFSavedDataViewController.m
+++ b/GSFDataCollecter/GSFSavedDataViewController.m
@@ -333,7 +333,10 @@
     dispatch_async(cleaningQueue, ^{
         [cleaner deleteFile:[self.fileList objectAtIndex:deleteButton.section]];
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self.datasource removeObjectAtIndex:self.selectedFeatureSection];
+            [self.datasource exchangeObjectAtIndex:deleteButton.section withObjectAtIndex:(self.datasource.count - 1)];
+            [self.datasource removeObjectAtIndex:(self.datasource.count - 1)];
+            [self.imageCache setObject:[self.imageCache objectForKey:[NSString stringWithFormat:@"Section%ld", (long)(self.imageCache.count - 1)]] forKey:[NSString stringWithFormat:@"Section%ld", (long)deleteButton.section]];
+            [self.imageCache removeObjectForKey:[NSString stringWithFormat:@"Section%ld", (long)(self.imageCache.count - 1)]];
             [self.tableView reloadData];
         });
     });


### PR DESCRIPTION
Fixed a bug when delete file would crash because of reloading the tableview. It now removes the deleted file data from the tableview and exchanges the row with the data from the last row.
Fixed a bug where timestamped data wasn’t loading in the saved data preview VC due to an update to the timestamp field that didn’t get updated in that VC.
Fixed a bug where if only one OpenCV switch was on, it would crash due to not checking if images were null. Also in the saved data table it wasn’t loading the data properties in properly. That is now fixed.
Added some appledoc comments in to generate documentation.
